### PR TITLE
fix: exclude .git directory from publish uploads

### DIFF
--- a/here-now/scripts/publish.sh
+++ b/here-now/scripts/publish.sh
@@ -220,6 +220,7 @@ elif [[ -d "$TARGET" ]]; then
     [[ "$rel" == ".DS_Store" ]] && continue
     [[ "$(basename "$rel")" == ".DS_Store" ]] && continue
     [[ "$rel" == ".herenow/fork-meta.json" ]] && continue
+    [[ "$rel" == ".git" || "$rel" =~ (^|/).git/ ]] && continue
     sz=$(wc -c < "$f" | tr -d ' ')
     ct=$(guess_content_type "$f")
     h=$(compute_sha256 "$f")

--- a/hermes/productivity/here.now/scripts/publish.sh
+++ b/hermes/productivity/here.now/scripts/publish.sh
@@ -220,6 +220,7 @@ elif [[ -d "$TARGET" ]]; then
     [[ "$rel" == ".DS_Store" ]] && continue
     [[ "$(basename "$rel")" == ".DS_Store" ]] && continue
     [[ "$rel" == ".herenow/fork-meta.json" ]] && continue
+    [[ "$rel" == ".git" || "$rel" =~ (^|/).git/ ]] && continue
     sz=$(wc -c < "$f" | tr -d ' ')
     ct=$(guess_content_type "$f")
     h=$(compute_sha256 "$f")

--- a/skills/here-now/scripts/publish.sh
+++ b/skills/here-now/scripts/publish.sh
@@ -220,6 +220,7 @@ elif [[ -d "$TARGET" ]]; then
     [[ "$rel" == ".DS_Store" ]] && continue
     [[ "$(basename "$rel")" == ".DS_Store" ]] && continue
     [[ "$rel" == ".herenow/fork-meta.json" ]] && continue
+    [[ "$rel" == ".git" || "$rel" =~ (^|/).git/ ]] && continue
     sz=$(wc -c < "$f" | tr -d ' ')
     ct=$(guess_content_type "$f")
     h=$(compute_sha256 "$f")


### PR DESCRIPTION
## Summary

- Adds `.git` directory exclusion to all three `publish.sh` scripts to prevent `.git` files from being uploaded when publishing a directory
- Previously only `skills/here-now/scripts/publish.sh` had this fix; now applied consistently to `here-now/scripts/publish.sh` and `hermes/productivity/here.now/scripts/publish.sh` as well