### PR TITLE
docs: preserve here-now triggers within index budget

### DIFF
--- a/here-now/SKILL.md
+++ b/here-now/SKILL.md
@@ -1,17 +1,6 @@
 ---
 name: here-now
-description: >
-  here.now lets agents publish websites and files to live URLs in seconds.
-  Publish HTML, documents, images, PDFs, videos, and static files to live
-  URLs at {slug}.here.now or custom domains. Use when asked to "publish
-  this", "host this", "deploy this", "share this on the web", "make a
-  website", "put this online", "create a webpage", "generate a URL",
-  "build a chatbot", "password protect this site", "make this site
-  private", or "share this site with only certain people". here.now also
-  includes workspaces — shared team accounts where Sites belong to the
-  team and serve at {label}.{workspace}.here.now — use when asked to
-  "publish this to our team workspace", "share this with my team", or
-  "put this in our company workspace".
+description: Publish websites and files to secure live URLs.
 ---
 
 # here.now
@@ -23,6 +12,16 @@ here.now lets agents publish websites and files to live URLs in seconds.
 The core primitive is a **Site**: publish a file or folder and get a live URL at `{slug}.here.now` or a custom domain. Every Site has access control: public link (default), password, or restricted invite-only access.
 
 here.now also includes **workspaces** — shared team accounts where Sites belong to the team and serve at `{label}.{workspace}.here.now` (see "Publish to a workspace" below).
+
+## When to Use
+
+Use this skill when the user asks to:
+
+- "publish this", "host this", "deploy this", or "share this on the web"
+- "make a website", "put this online", "create a webpage", or "generate a URL"
+- "build a chatbot"
+- "password protect this site", "make this site private", or "share this site with only certain people"
+- "publish this to our team workspace", "share this with my team", or "put this in our company workspace"
 
 To install or update (recommended): `npx skills add heredotnow/skill --skill here-now -g`
 

--- a/hermes/productivity/here.now/SKILL.md
+++ b/hermes/productivity/here.now/SKILL.md
@@ -1,17 +1,6 @@
 ---
 name: here.now
-description: >
-  here.now lets agents publish websites and files to live URLs in seconds.
-  Publish HTML, documents, images, PDFs, videos, and static files to live
-  URLs at {slug}.here.now or custom domains. Use when asked to "publish
-  this", "host this", "deploy this", "share this on the web", "make a
-  website", "put this online", "create a webpage", "generate a URL",
-  "build a chatbot", "password protect this site", "make this site
-  private", or "share this site with only certain people". here.now also
-  includes workspaces — shared team accounts where Sites belong to the
-  team and serve at {label}.{workspace}.here.now — use when asked to
-  "publish this to our team workspace", "share this with my team", or
-  "put this in our company workspace".
+description: Publish websites and files to secure live URLs.
 version: 1.28.0
 author: here.now
 license: MIT
@@ -34,6 +23,16 @@ here.now lets agents publish websites and files to live URLs in seconds.
 The core primitive is a **Site**: publish a file or folder and get a live URL at `{slug}.here.now` or a custom domain. Every Site has access control: public link (default), password, or restricted invite-only access.
 
 here.now also includes **workspaces** — shared team accounts where Sites belong to the team and serve at `{label}.{workspace}.here.now` (see "Publish to a workspace" below).
+
+## When to Use
+
+Use this skill when the user asks to:
+
+- "publish this", "host this", "deploy this", or "share this on the web"
+- "make a website", "put this online", "create a webpage", or "generate a URL"
+- "build a chatbot"
+- "password protect this site", "make this site private", or "share this site with only certain people"
+- "publish this to our team workspace", "share this with my team", or "put this in our company workspace"
 
 ## Current docs
 

--- a/skills/here-now/SKILL.md
+++ b/skills/here-now/SKILL.md
@@ -1,17 +1,6 @@
 ---
 name: here-now
-description: >
-  here.now lets agents publish websites and files to live URLs in seconds.
-  Publish HTML, documents, images, PDFs, videos, and static files to live
-  URLs at {slug}.here.now or custom domains. Use when asked to "publish
-  this", "host this", "deploy this", "share this on the web", "make a
-  website", "put this online", "create a webpage", "generate a URL",
-  "build a chatbot", "password protect this site", "make this site
-  private", or "share this site with only certain people". here.now also
-  includes workspaces — shared team accounts where Sites belong to the
-  team and serve at {label}.{workspace}.here.now — use when asked to
-  "publish this to our team workspace", "share this with my team", or
-  "put this in our company workspace".
+description: Publish websites and files to secure live URLs.
 ---
 
 # here.now
@@ -23,6 +12,16 @@ here.now lets agents publish websites and files to live URLs in seconds.
 The core primitive is a **Site**: publish a file or folder and get a live URL at `{slug}.here.now` or a custom domain. Every Site has access control: public link (default), password, or restricted invite-only access.
 
 here.now also includes **workspaces** — shared team accounts where Sites belong to the team and serve at `{label}.{workspace}.here.now` (see "Publish to a workspace" below).
+
+## When to Use
+
+Use this skill when the user asks to:
+
+- "publish this", "host this", "deploy this", or "share this on the web"
+- "make a website", "put this online", "create a webpage", or "generate a URL"
+- "build a chatbot"
+- "password protect this site", "make this site private", or "share this site with only certain people"
+- "publish this to our team workspace", "share this with my team", or "put this in our company workspace"
 
 To install or update (recommended): `npx skills add heredotnow/skill --skill here-now -g`
 


### PR DESCRIPTION
## Summary

- shorten the `here-now` description from 726 to 47 characters
- move all 15 original quoted trigger phrases into a `## When to Use` section
- keep the canonical, compatibility, and Hermes-specific copies aligned

## Why

Hermes limits skill descriptions to 60 characters in its prompt index. Longer descriptions render as the first 57 characters plus `...`.

The current description is 726 characters and appears as:

`here.now lets agents publish websites and files to live U...`

The body had no `## When to Use` section, so the truncated index text was the only trigger guidance available before loading the skill.

## Verification

- parsed all three files with Hermes' skill parser
- confirmed each description is 47 characters and is not truncated
- confirmed each file has exactly one `## When to Use` section
- confirmed all 15 original quoted trigger phrases remain in the body
- confirmed `here-now/SKILL.md` and `skills/here-now/SKILL.md` remain byte-identical
- `git diff --check` passed
- the four verification endpoints in `AGENTS.md` returned HTTP 200

This public repository is synchronized from a private product repository. Please apply the same source change there if these public files are generated.
